### PR TITLE
Resolve renderer memory leak

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,8 +44,10 @@ publishing {
 			url 'https://lazurite.dev/releases'
 
 			credentials {
-				username property('publish.lazurite.alias')
-				password property('publish.lazurite.secret')
+				if (project.hasProperty('publish.lazurite.alias')) {
+					username property('publish.lazurite.alias')
+					password property('publish.lazurite.secret')
+				}
 			}
 		}
 	}

--- a/src/main/java/dev/lazurite/polaroid/Polaroid.java
+++ b/src/main/java/dev/lazurite/polaroid/Polaroid.java
@@ -3,6 +3,7 @@ package dev.lazurite.polaroid;
 import dev.lazurite.polaroid.item.CameraItem;
 import net.minecraft.core.Registry;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
@@ -48,6 +49,11 @@ public class Polaroid implements ModInitializer {
 
         server.execute(() -> {
             /* Create a photo item with the necessary image bytes, then give to the player. */
+            if (!player.getMainHandItem().is(Polaroid.CAMERA_ITEM)) {
+                player.sendSystemMessage(Component.translatable("polaroid.invalid_item"));
+                return;
+            }
+
             final var photoItem = new ItemStack(PHOTO_ITEM);
             final var tag = photoItem.getOrCreateTag();
             tag.putInt("id", new Random().nextInt()); // lazy

--- a/src/main/java/dev/lazurite/polaroid/client/PolaroidClient.java
+++ b/src/main/java/dev/lazurite/polaroid/client/PolaroidClient.java
@@ -5,11 +5,13 @@ import dev.lazurite.polaroid.client.render.PolaroidPhotoRenderer;
 import dev.lazurite.polaroid.client.util.PhotoUtil;
 import dev.lazurite.polaroid.item.CameraItem;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.ClientPacketListener;
 import net.minecraft.resources.ResourceLocation;
 import org.quiltmc.loader.api.ModContainer;
 import org.quiltmc.qsl.base.api.entrypoint.client.ClientModInitializer;
 import org.quiltmc.qsl.lifecycle.api.client.event.ClientLifecycleEvents;
 import org.quiltmc.qsl.lifecycle.api.client.event.ClientTickEvents;
+import org.quiltmc.qsl.networking.api.client.ClientPlayConnectionEvents;
 
 public class PolaroidClient implements ClientModInitializer {
     public static final ResourceLocation CAMERA_SCOPE = new ResourceLocation(Polaroid.MODID, "textures/misc/polaroid_camera_scope.png");
@@ -18,11 +20,18 @@ public class PolaroidClient implements ClientModInitializer {
     @Override
     public void onInitializeClient(ModContainer mod) {
         ClientLifecycleEvents.READY.register(this::onClientReady);
+        ClientPlayConnectionEvents.DISCONNECT.register(this::onClientDisconnect);
         ClientTickEvents.START.register(this::onClientTick);
     }
 
     protected void onClientReady(Minecraft minecraft) {
         PHOTO_RENDERER = new PolaroidPhotoRenderer(Minecraft.getInstance().getTextureManager());
+    }
+
+    void onClientDisconnect(ClientPacketListener listener, Minecraft client) {
+        if (PHOTO_RENDERER != null) {
+            PHOTO_RENDERER.clear();
+        }
     }
 
     /**

--- a/src/main/java/dev/lazurite/polaroid/client/util/PhotoUtil.java
+++ b/src/main/java/dev/lazurite/polaroid/client/util/PhotoUtil.java
@@ -50,7 +50,6 @@ public final class PhotoUtil {
                 /* Send the byte information to the server */
                 final var buf = new FriendlyByteBuf(Unpooled.buffer());
                 buf.writeByteArray(squareImage.asByteArray());
-                System.out.println(squareImage.asByteArray().length);
                 ClientPlayNetworking.send(Polaroid.PHOTO_C2S, buf);
 
             } catch (IOException e) {

--- a/src/main/resources/assets/polaroid/lang/en_us.json
+++ b/src/main/resources/assets/polaroid/lang/en_us.json
@@ -2,5 +2,7 @@
   "item.polaroid.camera_item" : "Polaroid Camera",
   "item.polaroid.photo_item" : "Polaroid Photo",
 
-  "subtitle.polaroid.shutter": "Polaroid Camera Shutter"
+  "subtitle.polaroid.shutter": "Polaroid Camera Shutter",
+
+  "polaroid.invalid_item": "You must be holding a camera to take a photo!"
 }


### PR DESCRIPTION
These changes prevent unnecessary creation of native images (which store data in off-heap buffers/require manual memory management), and ensure that the images which are created are properly cleaned up. I took a pretty straightforward approach of clearing the client's cache upon disconnection, but a more aggressive strategy might make sense if users have further issues with memory consumption.

I've also tossed in a slight bit of hardening to ensure users don't create photos unless they actually have a camera, but for this mod to actually be safe to use outside of a server with only trusted friends you'd want to add further validation -- especially around image size. A consumable source item (film?) would limit the ability of users to fill up server memory with infinite photos too.

Thanks to @deli73 and @AurySystem for bouncing ideas off of :)